### PR TITLE
Add port_range_begin & port_range_end options

### DIFF
--- a/WdtOptions.h
+++ b/WdtOptions.h
@@ -108,6 +108,14 @@ class WdtOptions {
    */
   bool static_ports{false};
   /**
+   * Starting port to use. Must also specify port_range_end.
+   */
+  int32_t port_range_begin{0};
+  /**
+   * Last port to use (inclusive). Must also specify port_range_begin.
+   */
+  int32_t port_range_end{0};
+  /**
    * Maximum buffer size for the write on the sender
    * as well as while reading on receiver.
    */

--- a/util/ServerSocket.h
+++ b/util/ServerSocket.h
@@ -70,6 +70,23 @@ class ServerSocket : public WdtSocket {
   int listenInternal(struct addrinfo *info, const std::string &host);
 
   /**
+   * Bind a port from the given range.
+   *
+   * @param listeningFd     socket fd
+   * @param addr            address to listen to
+   * @param addrlen         size of addr
+   * @param begin           starting port to use
+   * @param end             last port to use (inclusive)
+   *
+   * @return 0 on success, -1 in case of error
+   */
+  static int bindFromPortRange(int listeningFd,
+                               struct sockaddr *addr,
+                               socklen_t addrlen,
+                               int begin,
+                               int end);
+
+  /**
    * Returns the selected port and new address list to use
    *
    * @param listeningFd     socket fd

--- a/util/WdtFlags.cpp.inc
+++ b/util/WdtFlags.cpp.inc
@@ -23,6 +23,8 @@ WDT_OPT(start_port, int32, "Starting port number for wdt, if set, "
                     "implies static_ports");
 WDT_OPT(num_ports, int32, "Number of sockets");
 WDT_OPT(static_ports, bool, "Use static ports (start_port) or any free port");
+WDT_OPT(port_range_begin, int32, "Starting port to use. Must also specify port_range_end");
+WDT_OPT(port_range_end, int32, "Last port to use (inclusive). Must also specify port_range_begin");
 WDT_OPT(ipv6, bool, "prefers ipv6");
 WDT_OPT(ipv4, bool, "use ipv4 only, takes precedence over -ipv6");
 WDT_OPT(dscp, int32, "specify DSCP flag for the sockets used in transfers");


### PR DESCRIPTION
This allows limiting the range of ports used by WDT when using dynamic ports.

C++, enjoy!

[branch ch11897]