### PR TITLE
Preserve Modification Times

### DIFF
--- a/ByteSource.h
+++ b/ByteSource.h
@@ -46,8 +46,6 @@ struct SourceMetaData {
   int64_t prevSeqId{0};
   /// file permission.
   int32_t permission{0};
-  /// last access time
-  struct timespec atime{0};
   /// modification time
   struct timespec mtime{0};
   /// If true, files are read using O_DIRECT or F_NOCACHE

--- a/ByteSource.h
+++ b/ByteSource.h
@@ -46,6 +46,10 @@ struct SourceMetaData {
   int64_t prevSeqId{0};
   /// file permission.
   int32_t permission{0};
+  /// last access time
+  struct timespec atime{0};
+  /// modification time
+  struct timespec mtime{0};
   /// If true, files are read using O_DIRECT or F_NOCACHE
   bool directReads{false};
   /// File descriptor. If this is not -1, then wdt uses this to read

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ cmake_minimum_required(VERSION 3.2)
 # Version is Major.Minor.YYMMDDX for up to 10 releases per day (X from 0 to 9)
 # Minor currently is also the protocol version - has to match with Protocol.cpp
 
-project("WDT" LANGUAGES C CXX VERSION 1.31.1704270)
+project("WDT" LANGUAGES C CXX VERSION 1.32.1704270)
 
 # On MacOS this requires the latest (master) CMake (and/or CMake 3.1.1/3.2)
 # WDT itself works fine with C++11 (gcc 4.8 for instance) but more recent folly

--- a/Protocol.cpp
+++ b/Protocol.cpp
@@ -35,7 +35,7 @@ const int Protocol::VARINT_CHANGE = 27;
 const int Protocol::HEART_BEAT_VERSION = 29;
 const int Protocol::PERIODIC_ENCRYPTION_IV_CHANGE_VERSION = 30;
 const int Protocol::PRESERVE_PERMISSION = 31;
-const int Protocol::PRESERVE_UTIMES = 32;
+const int Protocol::PRESERVE_MTIME = 32;
 
 /* All methods of Protocol class are static (functions) */
 
@@ -154,9 +154,7 @@ bool Protocol::encodeHeader(int senderProtocolVersion, char *dest, int64_t &off,
   if (ok && senderProtocolVersion >= PRESERVE_PERMISSION) {
     ok = encodeVarI64C(dest, umax, off, blockDetails.permission);
   }
-  if (ok && senderProtocolVersion >= PRESERVE_UTIMES) {
-    ok = encodeVarI64C(dest, umax, off, blockDetails.atime.tv_sec);
-    ok = encodeVarI64C(dest, umax, off, blockDetails.atime.tv_nsec);
+  if (ok && senderProtocolVersion >= PRESERVE_MTIME) {
     ok = encodeVarI64C(dest, umax, off, blockDetails.mtime.tv_sec);
     ok = encodeVarI64C(dest, umax, off, blockDetails.mtime.tv_nsec);
   }
@@ -193,9 +191,7 @@ bool Protocol::decodeHeader(int receiverProtocolVersion, char *src,
   if (ok && receiverProtocolVersion >= PRESERVE_PERMISSION) {
     ok = decodeInt32C(br, blockDetails.permission);
   }
-  if (ok && receiverProtocolVersion >= PRESERVE_UTIMES) {
-    ok = decodeInt64C(br, blockDetails.atime.tv_sec);
-    ok = decodeInt64C(br, blockDetails.atime.tv_nsec);
+  if (ok && receiverProtocolVersion >= PRESERVE_MTIME) {
     ok = decodeInt64C(br, blockDetails.mtime.tv_sec);
     ok = decodeInt64C(br, blockDetails.mtime.tv_nsec);
   }

--- a/Protocol.cpp
+++ b/Protocol.cpp
@@ -35,6 +35,7 @@ const int Protocol::VARINT_CHANGE = 27;
 const int Protocol::HEART_BEAT_VERSION = 29;
 const int Protocol::PERIODIC_ENCRYPTION_IV_CHANGE_VERSION = 30;
 const int Protocol::PRESERVE_PERMISSION = 31;
+const int Protocol::PRESERVE_UTIMES = 32;
 
 /* All methods of Protocol class are static (functions) */
 
@@ -153,6 +154,12 @@ bool Protocol::encodeHeader(int senderProtocolVersion, char *dest, int64_t &off,
   if (ok && senderProtocolVersion >= PRESERVE_PERMISSION) {
     ok = encodeVarI64C(dest, umax, off, blockDetails.permission);
   }
+  if (ok && senderProtocolVersion >= PRESERVE_UTIMES) {
+    ok = encodeVarI64C(dest, umax, off, blockDetails.atime.tv_sec);
+    ok = encodeVarI64C(dest, umax, off, blockDetails.atime.tv_nsec);
+    ok = encodeVarI64C(dest, umax, off, blockDetails.mtime.tv_sec);
+    ok = encodeVarI64C(dest, umax, off, blockDetails.mtime.tv_nsec);
+  }
   if (ok && senderProtocolVersion >= HEADER_FLAG_AND_PREV_SEQ_ID_VERSION) {
     uint8_t flags = blockDetails.allocationStatus;
     if (off >= max) {
@@ -185,6 +192,12 @@ bool Protocol::decodeHeader(int receiverProtocolVersion, char *src,
             decodeInt64C(br, blockDetails.fileSize);
   if (ok && receiverProtocolVersion >= PRESERVE_PERMISSION) {
     ok = decodeInt32C(br, blockDetails.permission);
+  }
+  if (ok && receiverProtocolVersion >= PRESERVE_UTIMES) {
+    ok = decodeInt64C(br, blockDetails.atime.tv_sec);
+    ok = decodeInt64C(br, blockDetails.atime.tv_nsec);
+    ok = decodeInt64C(br, blockDetails.mtime.tv_sec);
+    ok = decodeInt64C(br, blockDetails.mtime.tv_nsec);
   }
   if (ok && receiverProtocolVersion >= HEADER_FLAG_AND_PREV_SEQ_ID_VERSION) {
     if (br.empty()) {

--- a/Protocol.h
+++ b/Protocol.h
@@ -220,6 +220,10 @@ struct BlockDetails {
   int64_t prevSeqId{0};
   /// file permission
   int32_t permission{0644};
+  /// last access time
+  struct timespec atime{0};
+  /// modification time
+  struct timespec mtime{0};
 };
 
 /// structure representing settings cmd
@@ -276,6 +280,8 @@ class Protocol {
   static const int PERIODIC_ENCRYPTION_IV_CHANGE_VERSION;
   /// version from which file permission is preserved during transfer
   static const int PRESERVE_PERMISSION;
+  /// version from which file access & modification times are preserved during transfer
+  static const int PRESERVE_UTIMES;
 
   /// Both version, magic number and command byte
   enum CMD_MAGIC {
@@ -304,10 +310,10 @@ class Protocol {
 
   /// Max size of sender or receiver id
   static constexpr int64_t kMaxTransferIdLength = 1024;
-  /// 1 byte for cmd, 2 bytes for file-name length, Max size of filename, 5
-  /// variants(seq-id, data-size, offset, file-size, permission), 1 byte for
-  /// flag, 10 bytes prev seq-id
-  static constexpr int64_t kMaxHeader = 1 + 2 + PATH_MAX + 5 * 10 + 1 + 10;
+  /// 1 byte for cmd, 2 bytes for file-name length, Max size of filename, 9
+  /// variants(seq-id, data-size, offset, file-size, permission, atime.tv_sec, atime.tv_nsec, mtime.tv_sec, mtime.tv_nsec),
+  /// 1 byte for flag, 10 bytes prev seq-id
+  static constexpr int64_t kMaxHeader = 1 + 2 + PATH_MAX + 9 * 10 + 1 + 10;
   /// min number of bytes that must be send to unblock receiver
   static constexpr int64_t kMinBufLength = 256;
   /// max size of done command encoding(1 byte for cmd, 1 for status, 10 for

--- a/Protocol.h
+++ b/Protocol.h
@@ -220,8 +220,6 @@ struct BlockDetails {
   int64_t prevSeqId{0};
   /// file permission
   int32_t permission{0644};
-  /// last access time
-  struct timespec atime{0};
   /// modification time
   struct timespec mtime{0};
 };
@@ -280,8 +278,8 @@ class Protocol {
   static const int PERIODIC_ENCRYPTION_IV_CHANGE_VERSION;
   /// version from which file permission is preserved during transfer
   static const int PRESERVE_PERMISSION;
-  /// version from which file access & modification times are preserved during transfer
-  static const int PRESERVE_UTIMES;
+  /// version from which file modification times are preserved during transfer
+  static const int PRESERVE_MTIME;
 
   /// Both version, magic number and command byte
   enum CMD_MAGIC {
@@ -311,9 +309,9 @@ class Protocol {
   /// Max size of sender or receiver id
   static constexpr int64_t kMaxTransferIdLength = 1024;
   /// 1 byte for cmd, 2 bytes for file-name length, Max size of filename, 9
-  /// variants(seq-id, data-size, offset, file-size, permission, atime.tv_sec, atime.tv_nsec, mtime.tv_sec, mtime.tv_nsec),
+  /// variants(seq-id, data-size, offset, file-size, permission, mtime.tv_sec, mtime.tv_nsec),
   /// 1 byte for flag, 10 bytes prev seq-id
-  static constexpr int64_t kMaxHeader = 1 + 2 + PATH_MAX + 9 * 10 + 1 + 10;
+  static constexpr int64_t kMaxHeader = 1 + 2 + PATH_MAX + 7 * 10 + 1 + 10;
   /// min number of bytes that must be send to unblock receiver
   static constexpr int64_t kMinBufLength = 256;
   /// max size of done command encoding(1 byte for cmd, 1 for status, 10 for

--- a/SenderThread.cpp
+++ b/SenderThread.cpp
@@ -326,7 +326,6 @@ TransferStats SenderThread::sendOneByteSource(
   blockDetails.allocationStatus = metadata.allocationStatus;
   blockDetails.prevSeqId = metadata.prevSeqId;
   blockDetails.permission = metadata.permission;
-  blockDetails.atime = metadata.atime;
   blockDetails.mtime = metadata.mtime;
   Protocol::encodeHeader(wdtParent_->getProtocolVersion(), headerBuf, off,
                          Protocol::kMaxHeader, blockDetails);

--- a/SenderThread.cpp
+++ b/SenderThread.cpp
@@ -326,6 +326,8 @@ TransferStats SenderThread::sendOneByteSource(
   blockDetails.allocationStatus = metadata.allocationStatus;
   blockDetails.prevSeqId = metadata.prevSeqId;
   blockDetails.permission = metadata.permission;
+  blockDetails.atime = metadata.atime;
+  blockDetails.mtime = metadata.mtime;
   Protocol::encodeHeader(wdtParent_->getProtocolVersion(), headerBuf, off,
                          Protocol::kMaxHeader, blockDetails);
   int16_t littleEndianOff = folly::Endian::little((int16_t)off);

--- a/WdtConfig.h
+++ b/WdtConfig.h
@@ -10,10 +10,10 @@
 #include <fcntl.h>
 
 #define WDT_VERSION_MAJOR 1
-#define WDT_VERSION_MINOR 31
+#define WDT_VERSION_MINOR 32
 #define WDT_VERSION_BUILD 1704270
 // Add -fbcode to version str
-#define WDT_VERSION_STR "1.31.1704270-fbcode"
+#define WDT_VERSION_STR "1.32.1704270-fbcode"
 // Tie minor and proto version
 #define WDT_PROTOCOL_VERSION WDT_VERSION_MINOR
 

--- a/WdtTransferRequest.h
+++ b/WdtTransferRequest.h
@@ -10,6 +10,7 @@
 #include <wdt/ErrorCodes.h>
 #include <wdt/Protocol.h>
 #include <wdt/WdtOptions.h>
+#include <sys/types.h>
 #include <map>
 #include <memory>
 #include <string>
@@ -37,9 +38,13 @@ struct WdtFileInfo {
   bool directReads{false};
   /// File permission.
   int32_t permission;
+  /// Last access time.
+  struct timespec atime;
+  /// Modification time;
+  struct timespec mtime;
   /// Constructor for file info with name, size, odirect request and permission
   WdtFileInfo(const std::string& name, int64_t size, bool directReads,
-              int32_t perm);
+              int32_t perm, const struct timespec& atime, const struct timespec& mtime);
   /// Constructor for file info with name, size and odirect request
   WdtFileInfo(const std::string& name, int64_t size, bool directReads);
   /**

--- a/WdtTransferRequest.h
+++ b/WdtTransferRequest.h
@@ -36,15 +36,13 @@ struct WdtFileInfo {
   /// Whether read should be done using o_direct. If fd is set, this flag will
   /// be set automatically to match the fd open mode
   bool directReads{false};
-  /// File permission.
+  /// File permission
   int32_t permission;
-  /// Last access time.
-  struct timespec atime;
-  /// Modification time;
+  /// Modification time
   struct timespec mtime;
   /// Constructor for file info with name, size, odirect request and permission
   WdtFileInfo(const std::string& name, int64_t size, bool directReads,
-              int32_t perm, const struct timespec& atime, const struct timespec& mtime);
+              int32_t perm, const struct timespec& mtime);
   /// Constructor for file info with name, size and odirect request
   WdtFileInfo(const std::string& name, int64_t size, bool directReads);
   /**

--- a/util/DirectorySourceQueue.cpp
+++ b/util/DirectorySourceQueue.cpp
@@ -33,10 +33,9 @@ WdtFileInfo::WdtFileInfo(const string &name, int64_t size, bool doDirectReads)
 }
 
 WdtFileInfo::WdtFileInfo(const string &name, int64_t size, bool doDirectReads,
-                         int32_t perm, const struct timespec& atime, const struct timespec& mtime)
+                         int32_t perm, const struct timespec& mtime)
     : WdtFileInfo(name, size, doDirectReads) {
   permission = perm;
-  this->atime = atime;
   this->mtime = mtime;
 }
 
@@ -374,7 +373,7 @@ bool DirectorySourceQueue::explore() {
           }
           const int perm = getPermission(fileStat.st_mode);
           WdtFileInfo fileInfo(newRelativePath, fileStat.st_size, directReads_,
-                               perm, fileStat.st_atim, fileStat.st_mtim);
+                               perm, fileStat.st_mtim);
           createIntoQueue(newFullPath, fileInfo);
           continue;
         }
@@ -455,7 +454,6 @@ void DirectorySourceQueue::createIntoQueue(const string &fullPath,
   metadata->directReads = fileInfo.directReads;
   metadata->size = fileInfo.fileSize;
   metadata->permission = fileInfo.permission;
-  metadata->atime = fileInfo.atime;
   metadata->mtime = fileInfo.mtime;
   if ((openFilesDuringDiscovery_ != 0) && (metadata->fd < 0)) {
     metadata->fd =
@@ -591,7 +589,6 @@ bool DirectorySourceQueue::enqueueFiles() {
       info.fileSize = fileStat.st_size;
     }
     info.permission = getPermission(fileStat.st_mode);
-    info.atime = fileStat.st_atim;
     info.mtime = fileStat.st_mtim;
     createIntoQueue(fullPath, info);
   }

--- a/util/FileWriter.cpp
+++ b/util/FileWriter.cpp
@@ -64,8 +64,8 @@ ErrorCode FileWriter::sync() {
     // File was either never opened or already closed
     return OK;
   }
-  if (blockDetails_->atime.tv_sec != 0 || blockDetails_->mtime.tv_sec != 0) {
-    struct timespec times[] = {blockDetails_->atime, blockDetails_->mtime};
+  if (blockDetails_->mtime.tv_sec != 0) {
+    struct timespec times[] = {{0, UTIME_OMIT}, blockDetails_->mtime};
     if (futimens(fd_, times) < 0) {
       WPLOG(ERROR) << "Unable to futimens() fd " << fd_;
       return FILE_WRITE_ERROR;


### PR DESCRIPTION
### Caveat Emptor...

1. Tests are not working, and I haven't updated them as such to test this.
2. This changes the protocol, messing with the version negotiation and backwards compatibility.
3. I implemented this in a way that is not likely to be mergable upstream, using `struct timespec` directly in their struct, not worrying about code portability... and it's based changes reverted upstream to preserve file permissions, probably because they had issues.

### Dev Setup using VS Code - Remote Containers
(For future reference, if someone needs it)

1. `git clone https://github.com/OceanCodes/wdt`
2. `git clone https://github.com/facebook/folly.git`, `git -C folly checkout b440ee450a9461a57e05ef9732cd99bd4a75db00`
3. Create in same folder:

`.devcontainer/devcontainer.json`:
```jsonc
// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
// https://github.com/microsoft/vscode-dev-containers/tree/v0.128.0/containers/cpp
{
	"name": "C++",
	"dockerFile": "Dockerfile",
	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],

	// Set *default* container specific settings.json values on container create.
	"settings": { 
		"terminal.integrated.shell.linux": "/bin/bash"
	},

	// Add the IDs of extensions you want installed when the container is created.
	"extensions": [
		"ms-vscode.cpptools"
	]

	// Use 'forwardPorts' to make a list of ports inside the container available locally.
	// "forwardPorts": [],

	// Use 'postCreateCommand' to run commands after the container is created.
	// "postCreateCommand": "gcc -v",

	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
	// "remoteUser": "vscode"

}
```

`.devcontainer/Dockerfile`:
```dockerfile
#-------------------------------------------------------------------------------------------------------------
# Copyright (c) Microsoft Corporation. All rights reserved.
# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
#-------------------------------------------------------------------------------------------------------------

FROM mcr.microsoft.com/vscode/devcontainers/base:0-buster

# This Dockerfile's base image has a non-root user with sudo access. Use the "remoteUser"
# property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
# will be updated to match your local UID/GID (when using the dockerFile property).
# See https://aka.ms/vscode-remote/containers/non-root-user for details.
ARG USERNAME=vscode
ARG USER_UID=1000
ARG USER_GID=$USER_UID

# Configure apt and install packages
RUN apt-get update \
    && export DEBIAN_FRONTEND=noninteractive \
    #
    # Install C++ tools
    && apt-get -y install build-essential cmake cppcheck valgrind \
    #
    # [Optional] Update UID/GID if needed
    && if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then \
        groupmod --gid $USER_GID $USERNAME \
        && usermod --uid $USER_UID --gid $USER_GID $USERNAME \
        && chown -R $USER_UID:$USER_GID /home/$USERNAME; \
    fi \
    #
    # Clean up
    && apt-get autoremove -y \
    && apt-get clean -y \
    && rm -rf /var/lib/apt/lists/*

RUN apt-get update && apt-get install -y \
        build-essential \
        git \
        cmake \
        libssl-dev \
        libgoogle-glog-dev \
        libboost-all-dev \
        libdouble-conversion-dev \
        libjemalloc-dev \
    && rm -rf /var/lib/apt/lists/*

```

`wdt.code-workspace`:
```jsonc
{
	"folders": [
		{
			"path": "wdt"
		},
		{
			"path": "folly"
		},
		{
			"path": "docker"
		},
		{
			"path": "build"
		},
		{
			"path": ".devcontainer"
		}
	],
	"settings": {
		"files.associations": {
			"algorithm": "cpp",
			"complex": "cpp",
			"new": "cpp",
			"cctype": "cpp",
			"clocale": "cpp",
			"cmath": "cpp",
			"csignal": "cpp",
			"cstdarg": "cpp",
			"cstddef": "cpp",
			"cstdio": "cpp",
			"cstdlib": "cpp",
			"cstring": "cpp",
			"ctime": "cpp",
			"cwchar": "cpp",
			"cwctype": "cpp",
			"any": "cpp",
			"array": "cpp",
			"atomic": "cpp",
			"strstream": "cpp",
			"*.tcc": "cpp",
			"bitset": "cpp",
			"chrono": "cpp",
			"cinttypes": "cpp",
			"condition_variable": "cpp",
			"cstdint": "cpp",
			"deque": "cpp",
			"forward_list": "cpp",
			"list": "cpp",
			"unordered_map": "cpp",
			"unordered_set": "cpp",
			"vector": "cpp",
			"exception": "cpp",
			"functional": "cpp",
			"iterator": "cpp",
			"map": "cpp",
			"memory": "cpp",
			"memory_resource": "cpp",
			"numeric": "cpp",
			"optional": "cpp",
			"random": "cpp",
			"ratio": "cpp",
			"regex": "cpp",
			"set": "cpp",
			"string": "cpp",
			"string_view": "cpp",
			"system_error": "cpp",
			"tuple": "cpp",
			"type_traits": "cpp",
			"utility": "cpp",
			"fstream": "cpp",
			"future": "cpp",
			"initializer_list": "cpp",
			"iomanip": "cpp",
			"iosfwd": "cpp",
			"iostream": "cpp",
			"istream": "cpp",
			"limits": "cpp",
			"mutex": "cpp",
			"ostream": "cpp",
			"scoped_allocator": "cpp",
			"shared_mutex": "cpp",
			"sstream": "cpp",
			"stdexcept": "cpp",
			"streambuf": "cpp",
			"thread": "cpp",
			"cfenv": "cpp",
			"typeindex": "cpp",
			"typeinfo": "cpp",
			"variant": "cpp",
			"queue": "cpp",
			"stack": "cpp"
		}
	}
}
```

(And under WDT folder):
`wdt/.vscode/c_cpp_properties.json`:
```jsonc
{
    "configurations": [
        {
            "name": "Linux",
            "includePath": [
                "${workspaceFolder}/**",
                "${workspaceFolder}/..",
                "${workspaceFolder}/../folly",
                "${workspaceFolder}/../build"
            ],
            "defines": [],
            "compilerPath": "/usr/bin/gcc",
            "cStandard": "c11",
            "cppStandard": "gnu++14",
            "intelliSenseMode": "clang-x64"
        }
    ],
    "version": 4
}
```

`wdt/.vscode/launch.json`:
```jsonc
{
    // Use IntelliSense to learn about possible attributes.
    // Hover to view descriptions of existing attributes.
    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
    "version": "0.2.0",
    "configurations": [
        {
            "name": "wdt receiver",
            "type": "cppdbg",
            "request": "launch",
            "program": "${workspaceFolder}/../build/_bin/wdt/wdt",
            "args": ["-directory", "build2"],
            "stopAtEntry": false,
            "cwd": "${workspaceFolder}",
            "environment": [],
            "externalConsole": false,
            "MIMode": "gdb",
            "setupCommands": [
                {
                    "description": "Enable pretty-printing for gdb",
                    "text": "-enable-pretty-printing",
                    "ignoreFailures": true
                }
            ]
        }
    ]
}
```

`wdt/.vscode/tasks.json`:
```jsonc
{
    // See https://go.microsoft.com/fwlink/?LinkId=733558
    // for the documentation about the tasks.json format
    "version": "2.0.0",
    "tasks": [
        {
            "label": "build",
            "type": "shell",
            "command": "make -j4",
            "options": {
                "cwd": "${workspaceFolder}/../build"
            },
            "group": {
                "kind": "build",
                "isDefault": true
            },
            "problemMatcher": [
                "$gcc"
            ]
        }
    ]
}
```